### PR TITLE
feat(604): Router starts a build using the correct executor

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,59 @@
+'use strict';
+
+// Key in annotations object that maps to an executor NPM module
+// value is a placeholder until resolution to screwdriver-cd/screwdriver#595
+const ANNOTATION_EXECUTOR_TYPE = 'beta.screwdriver.cd/executor';
+const Executor = require('screwdriver-executor-base');
+
+class ExecutorRouter extends Executor {
+    /**
+     * Constructs a router for different Executor strategies.
+     * @method constructor
+     * @param  {Object}         options
+     * @param  {Array|String}   options.plugins                Array of plugins to load or a single plugin string
+     * @param  {String}         options.plugins[x].moduleName  Name of the executor NPM module to load
+     * @param  {String}         options.plugins[x].options     Configuration to construct the module with
+     */
+    constructor(options = {}) {
+        super();
+
+        const plugins = options.plugins;
+        const registrations = (Array.isArray(plugins)) ? plugins : [plugins];
+
+        registrations.forEach((plugin, index) => {
+            // eslint-disable-next-line global-require, import/no-dynamic-require
+            const ExecutorPlugin = require(plugin.name);
+
+            const executorPlugin = new ExecutorPlugin(plugin.options);
+
+            // Set the default executor
+            if (index === 0) {
+                this.default_executor = executorPlugin;
+            }
+
+            this[plugin.name] = executorPlugin;
+        });
+    }
+
+    /**
+     * Starts a new build in an executor
+     * @method start
+     * @param {Object} config               Configuration
+     * @param {Object} [config.annotations] Optional key/value object
+     * @param {String} config.apiUri        Screwdriver's API
+     * @param {String} config.buildId       Unique ID for a build
+     * @param {String} config.container     Container for the build to run in
+     * @param {String} config.token         JWT to act on behalf of the build
+     * @return {Promise}
+     */
+    start(config) {
+        const annotations = config.annotations || {};
+        const executorType = annotations[ANNOTATION_EXECUTOR_TYPE];
+        // Route to executor specified in annotations or use default executor
+        const executor = this[executorType] || this.default_executor;
+
+        return executor.start(config);
+    }
+}
+
+module.exports = ExecutorRouter;

--- a/package.json
+++ b/package.json
@@ -35,9 +35,13 @@
     "chai": "^3.5.0",
     "eslint": "^3.9.1",
     "eslint-config-screwdriver": "^2.0.9",
-    "jenkins-mocha": "^4.0.0"
+    "jenkins-mocha": "^4.0.0",
+    "mockery": "^2.0.0",
+    "sinon": "^2.3.4"
   },
-  "dependencies": {},
+  "dependencies": {
+    "screwdriver-executor-base": "^5.2.2"
+  },
   "release": {
     "debug": false,
     "verifyConditions": {

--- a/test/data/testExecutor.js
+++ b/test/data/testExecutor.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const ExecutorBase = require('screwdriver-executor-base');
+
+module.exports = (stubsMap) => {
+    /**
+     * Generic executor class for testing
+     * @type {Class}
+     */
+    const TestExecutorClass = class TestExecutor extends ExecutorBase {
+        constructor(options) {
+            super();
+
+            this.options = options;
+
+            Object.keys(stubsMap).forEach((key) => {
+                this[key] = stubsMap[key];
+            });
+        }
+
+        get constructorParams() {
+            return this.options;
+        }
+    };
+
+    return TestExecutorClass;
+};

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,9 +1,168 @@
 'use strict';
 
-const assert = require('chai').assert;
+/* eslint-disable no-underscore-dangle */
+
+const chai = require('chai');
+const assert = chai.assert;
+const mockery = require('mockery');
+const sinon = require('sinon');
+const testExecutor = require('./data/testExecutor');
+
+sinon.assert.expose(chai.assert, { prefix: '' });
 
 describe('index test', () => {
-    it('does not fail', () => {
-        assert.isTrue(true);
+    let Executor;
+    let executor;
+    let fsMock;
+    let k8sExecutorMock;
+    let exampleExecutorMock;
+    const pluginOptions = {
+        ecosystem: {
+            api: 'http://api.com',
+            store: 'http://store.com'
+        }
+    };
+
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+    });
+
+    beforeEach(() => {
+        fsMock = {
+            readFileSync: sinon.stub()
+        };
+
+        fsMock.readFileSync.withArgs('/var/run/secrets/kubernetes.io/serviceaccount/token')
+            .returns('api_key');
+
+        k8sExecutorMock = {
+            _start: sinon.stub()
+        };
+        exampleExecutorMock = {
+            _start: sinon.stub()
+        };
+
+        mockery.registerMock('fs', fsMock);
+        mockery.registerMock('screwdriver-executor-k8s', testExecutor(k8sExecutorMock));
+        mockery.registerMock('my-example-executor', testExecutor(exampleExecutorMock));
+
+        // eslint-disable-next-line global-require
+        Executor = require('../index');
+
+        executor = new Executor({
+            plugins: [
+                {
+                    name: 'screwdriver-executor-k8s',
+                    options: pluginOptions
+                },
+                {
+                    name: 'my-example-executor',
+                    options: pluginOptions
+                }
+            ]
+        });
+    });
+
+    afterEach(() => {
+        mockery.deregisterAll();
+    });
+
+    describe('construction', () => {
+        it('registers multiple plugins', () => {
+            const executorKubernetes = executor['screwdriver-executor-k8s'];
+            const exampleExecutor = executor['my-example-executor'];
+
+            assert.deepEqual(executorKubernetes.constructorParams, pluginOptions);
+            assert.deepEqual(exampleExecutor.constructorParams, pluginOptions);
+        });
+
+        it('registers a single plugin', () => {
+            executor = new Executor({
+                plugins: {
+                    name: 'screwdriver-executor-k8s',
+                    options: pluginOptions
+                }
+            });
+
+            const executorKubernetes = executor['screwdriver-executor-k8s'];
+
+            assert.deepEqual(executorKubernetes.constructorParams, pluginOptions);
+        });
+    });
+
+    describe('start', () => {
+        it('default executor is the first one when given no executor annotation', () => {
+            k8sExecutorMock._start.resolves('k8sExecutorResult');
+
+            return executor.start({
+                buildId: 920,
+                container: 'node:4',
+                apiUri: 'http://api.com',
+                token: 'qwer'
+            }).then((result) => {
+                assert.strictEqual(result, 'k8sExecutorResult');
+                assert.calledOnce(k8sExecutorMock._start);
+                assert.notCalled(exampleExecutorMock._start);
+            });
+        });
+
+        it('default executor is the first one when given an invalid executor annotation', () => {
+            k8sExecutorMock._start.resolves('k8sExecutorResult');
+            exampleExecutorMock._start.rejects();
+
+            return executor.start({
+                annotations: {
+                    'beta.screwdriver.cd/executor': 'darrenIsSometimesRight'
+                },
+                buildId: 920,
+                container: 'node:4',
+                apiUri: 'http://api.com',
+                token: 'qwer'
+            }).then((result) => {
+                assert.strictEqual(result, 'k8sExecutorResult');
+                assert.calledOnce(k8sExecutorMock._start);
+                assert.notCalled(exampleExecutorMock._start);
+            });
+        });
+
+        it('uses an annotation to determine which executor to call', () => {
+            k8sExecutorMock._start.rejects();
+            exampleExecutorMock._start.resolves('exampleExecutorResult');
+
+            return executor.start({
+                annotations: {
+                    'beta.screwdriver.cd/executor': 'my-example-executor'
+                },
+                buildId: 920,
+                container: 'node:4',
+                apiUri: 'http://api.com',
+                token: 'qwer'
+            }).then((result) => {
+                assert.strictEqual(result, 'exampleExecutorResult');
+                assert.calledOnce(exampleExecutorMock._start);
+                assert.notCalled(k8sExecutorMock._start);
+            });
+        });
+
+        it('propogates the failure from initiating a start', () => {
+            const testError = new Error('triggeredError');
+
+            k8sExecutorMock._start.rejects(testError);
+
+            return executor.start({
+                annotations: {
+                    'beta.screwdriver.cd/executor': 'screwdriver-executor-k8s'
+                },
+                buildId: 920,
+                container: 'node:4',
+                apiUri: 'http://api.com',
+                token: 'qwer'
+            }).then(assert.fail, (err) => {
+                assert.deepEqual(err, testError);
+            });
+        });
     });
 });


### PR DESCRIPTION
## Context
In order to support multiple executors, we need a router to direct build creation to different specified executors.

## In this PR
The router will set the first plugin listed as a default executor. It will also check for the key `beta.screwdriver.cd/executor` to determine which executor to use when starting a build. (The value should be the npm module name for the desired executor, e.g.: `screwdriver-executor-k8s`.) If no annotation or an invalid annotation is passed in, the default executor will be used to start the build.

## "We'll fix it in post"
There was a merge conflict and there's an ugly extra commit; please Squash and Merge (using semantic-release syntax)

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/604