### PR TITLE
fix(604): default executor is a string and not the actual module

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,13 +17,13 @@ class ExecutorRouter extends Executor {
     constructor(config = {}) {
         const ecosystem = config.ecosystem || {};
         const executorConfig = config.executor;
+        const defaultPlugin = config.defaultPlugin;
 
         if (!executorConfig || !(Array.isArray(executorConfig)) || executorConfig.length === 0) {
             throw new Error('No executor config passed in.');
         }
 
         super();
-        this.defaultExecutor = config.defaultPlugin;
 
         executorConfig.forEach((plugin) => {
             let ExecutorPlugin;
@@ -40,8 +40,11 @@ class ExecutorRouter extends Executor {
             const options = Object.assign({ ecosystem }, plugin.options); // Add ecosystem to executor options
             const executorPlugin = new ExecutorPlugin(options);
 
-            // Set the default executor
-            if (!this.defaultExecutor && !config.defaultPlugin) {
+            if (defaultPlugin && defaultPlugin === plugin.name) {
+                // set the default plugin to the desired one
+                this.defaultExecutor = executorPlugin;
+            } else if (!defaultPlugin && !this.defaultExecutor) {
+                // When given no default plugin, use the first module we instantiated
                 this.defaultExecutor = executorPlugin;
             }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -256,6 +256,33 @@ describe('index test', () => {
     });
 
     describe('start', () => {
+        it('default executor when no annotation is given', () => {
+            executor = new Executor({
+                defaultPlugin: 'example',
+                ecosystem,
+                executor: [
+                    {
+                        name: 'k8s',
+                        options: k8sPluginOptions
+                    },
+                    {
+                        name: 'example',
+                        options: examplePluginOptions
+                    }
+                ]
+            });
+            exampleExecutorMock._start.resolves('exampleExecutorMockResult');
+
+            return executor.start({
+                buildId: 920,
+                container: 'node:4',
+                apiUri: 'http://api.com',
+                token: 'asdf'
+            }).then((result) => {
+                assert.strictEqual(result, 'exampleExecutorMockResult');
+            });
+        });
+
         it('default executor is the first one when given no executor annotation', () => {
             k8sExecutorMock._start.resolves('k8sExecutorResult');
 


### PR DESCRIPTION
## Context

When passed in a default plugin, the plugin's name is saved and not the executor-plugin itself. This leads to an error when executing a new build: 

```
 170623/003704.593, (1498178220873:30cf7cdecfb0:17:j494hi9e:10132) [request,server,error] data: TypeError: executor.start is not a function
     at ExecutorRouter.start (/usr/src/app/node_modules/screwdriver-executor-router/index.js:72:25)
     at job.pipeline.then.pipeline (/usr/src/app/node_modules/screwdriver-models/lib/build.js:185:36)
```

## Objective

This change correctly sets the default executor to the desired module.

## Reference

