### PR TITLE
Disable mockery after tests, fix jsdoc for constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ class ExecutorRouter extends Executor {
      * @param  {Object}         config                      Object with executor and ecosystem
      * @param  {String}         [config.defaultPlugin]      Optional default executor
      * @param  {Object}         [config.ecosystem]          Optional object with ecosystem values
-     * @param  {Array|Object}   config.executor             Array of executors to load or a single executor object
+     * @param  {Array}   config.executor                    Array of executors to load
      * @param  {String}         config.executor[x].name     Name of the executor NPM module to load
      * @param  {String}         config.executor[x].options  Configuration to construct the module with
      */

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -89,6 +89,10 @@ describe('index test', () => {
         mockery.deregisterAll();
     });
 
+    after(() => {
+        mockery.disable();
+    });
+
     describe('construction', () => {
         let exampleOptions;
         let k8sOptions;


### PR DESCRIPTION
## Context
While reviewing https://github.com/screwdriver-cd/executor-queue/pull/2 a few problems were found that are also present here. This PR fixes those.

## Objective
* Disable `mockery` after tests are finished
* Update JSdoc on the constructor as with the way it's currently written it will fail if not given an array

## Related
https://github.com/screwdriver-cd/executor-queue/pull/2