### PR TITLE
fix(hip): Upgrade to node:8

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ class ExecutorRouter extends Executor {
      * @param  {Object}         config                      Object with executor and ecosystem
      * @param  {String}         [config.defaultPlugin]      Optional default executor
      * @param  {Object}         [config.ecosystem]          Optional object with ecosystem values
-     * @param  {Array}   config.executor                    Array of executors to load
+     * @param  {Array}          config.executor             Array of executors to load
      * @param  {String}         config.executor[x].name     Name of the executor NPM module to load
      * @param  {String}         config.executor[x].options  Configuration to construct the module with
      */
@@ -59,12 +59,12 @@ class ExecutorRouter extends Executor {
     /**
      * Starts a new build in an executor
      * @method _start
-     * @param {Object} config               Configuration
-     * @param {Object} [config.annotations] Optional key/value object
-     * @param {String} config.apiUri        Screwdriver's API
-     * @param {String} config.buildId       Unique ID for a build
-     * @param {String} config.container     Container for the build to run in
-     * @param {String} config.token         JWT to act on behalf of the build
+     * @param  {Object} config               Configuration
+     * @param  {Object} [config.annotations] Optional key/value object
+     * @param  {String} config.apiUri        Screwdriver's API
+     * @param  {String} config.buildId       Unique ID for a build
+     * @param  {String} config.container     Container for the build to run in
+     * @param  {String} config.token         JWT to act on behalf of the build
      * @return {Promise}
      */
     _start(config) {
@@ -78,9 +78,9 @@ class ExecutorRouter extends Executor {
     /**
      * Stop a running or finished build
      * @method _stop
-     * @param {Object} config               Configuration
-     * @param {Object} [config.annotations] Optional key/value object
-     * @param {String} config.buildId       Unique ID for a build
+     * @param  {Object} config               Configuration
+     * @param  {Object} [config.annotations] Optional key/value object
+     * @param  {String} config.buildId       Unique ID for a build
      * @return {Promise}
      */
     _stop(config) {

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
   ],
   "devDependencies": {
     "chai": "^3.5.0",
-    "eslint": "^3.9.1",
-    "eslint-config-screwdriver": "^2.0.9",
+    "eslint": "^4.19.1",
+    "eslint-config-screwdriver": "^3.0.0",
     "jenkins-mocha": "^4.0.0",
     "mockery": "^2.0.0",
     "sinon": "^2.3.4"

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-    image: node:6
+    image: node:8
 
 jobs:
     main:
@@ -11,7 +11,7 @@ jobs:
             - ~commit
 
     publish:
-        template: screwdriver-cd/semantic-release 
+        template: screwdriver-cd/semantic-release
         secrets:
             # Publishing to NPM
             - NPM_TOKEN


### PR DESCRIPTION
## Context

Node.js 6 is slowly becoming deprecated, with popular packages such as `semantic-release` no longer supporting it.

## Objective

* Change image in `screwdriver.yaml` to `node:8`