### PR TITLE
feat(2083): Randomize build executor selection

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,44 +16,110 @@ class ExecutorRouter extends Executor {
      */
     constructor(config = {}) {
         const ecosystem = config.ecosystem || {};
-        const executorConfig = config.executor;
-        const defaultPlugin = config.defaultPlugin;
+        const { executor, defaultPlugin } = config;
 
-        if (!executorConfig || !(Array.isArray(executorConfig)) || executorConfig.length === 0) {
+        if (!executor || !Array.isArray(executor) || executor.length === 0) {
             throw new Error('No executor config passed in.');
         }
-
         super();
 
-        executorConfig.forEach((plugin) => {
-            let ExecutorPlugin;
+        let ExecutorPlugin;
 
+        this._executors = [];
+
+        executor.forEach(plugin => {
             try {
                 // eslint-disable-next-line global-require, import/no-dynamic-require
                 ExecutorPlugin = require(`screwdriver-executor-${plugin.name}`);
+                this._executors.push(plugin);
             } catch (err) {
-                console.error(err);
+                console.error(err.message);
 
                 return;
             }
+            // Add ecosystem to executor options
+            const options = Object.assign({ ecosystem }, plugin.options);
 
-            const options = Object.assign({ ecosystem }, plugin.options); // Add ecosystem to executor options
-            const executorPlugin = new ExecutorPlugin(options);
-
-            if (defaultPlugin && defaultPlugin === plugin.name) {
-                // set the default plugin to the desired one
-                this.defaultExecutor = executorPlugin;
-            } else if (!defaultPlugin && !this.defaultExecutor) {
-                // When given no default plugin, use the first module we instantiated
-                this.defaultExecutor = executorPlugin;
-            }
-
-            this[plugin.name] = executorPlugin;
+            this[plugin.name] = new ExecutorPlugin(options);
         });
 
-        if (!this.defaultExecutor) {
+        // executor rules chain
+        this._executorRules = [
+            {
+                name: 'annotated',
+                priority: 1,
+                check: buildConfig => {
+                    const annotations = this.parseAnnotations(buildConfig.annotations || {});
+
+                    return annotations[ANNOTATION_EXECUTOR_TYPE];
+                }
+            },
+            {
+                name: 'weighted',
+                priority: 2,
+                check: () => this.getWeightedExecutor(this._executors)
+            },
+            {
+                name: 'default',
+                priority: 3,
+                check: () => defaultPlugin || (this._executors[0] && this._executors[0].name)
+            }
+        ];
+        // sort by priority and store
+        this._executorRules.sort((a, b) => a.priority - b.priority);
+
+        if (!this._executorRules.find(a => a.name === 'default').check()) {
             throw new Error('No default executor set.');
         }
+    }
+
+    /**
+     * Returns the executor based on a random selection optimized on weightage
+     * @param {Array} executors
+     * @return {String} executor name
+     */
+    getWeightedExecutor(executors) {
+        const totalWeight = executors.reduce((prev, curr) => prev + (curr.weightage || 0), 0);
+
+        if (totalWeight === 0) {
+            return undefined;
+        }
+        const number = Math.floor(Math.random() * totalWeight);
+
+        let sum = 0;
+
+        for (let i = 0; i < executors.length; i += 1) {
+            sum += executors[i].weightage;
+
+            if (number < sum) return executors[i].name;
+        }
+
+        return executors[0].name;
+    }
+
+    /**
+     * Evaluates the executor rules by priority and returns the first matching executor
+     * @method evaluateRules
+     * @param  {Object} config               Configuration
+     * @param  {Object} [config.annotations] Optional key/value object
+     * @param  {String} config.apiUri        Screwdriver's API
+     * @param  {Object} [config.build]       Build object
+     * @param  {String} config.buildId       Unique ID for a build
+     * @param  {String} config.container     Container for the build to run in
+     * @param  {String} config.token         JWT to act on behalf of the build
+     * @return {Object} executor object
+     */
+    evaluateRules(config) {
+        let executorName;
+
+        for (const rule of this._executorRules) {
+            executorName = rule.check(config);
+            if (executorName && this[executorName]) {
+                break;
+            }
+        }
+
+        return this[executorName];
     }
 
     /**
@@ -69,9 +135,7 @@ class ExecutorRouter extends Executor {
      * @return {Promise}
      */
     _start(config) {
-        const annotations = this.parseAnnotations(config.annotations || {});
-        const executorType = annotations[ANNOTATION_EXECUTOR_TYPE];
-        const executor = this[executorType] || this.defaultExecutor; // Route to executor (based on annotations) or use default executor
+        const executor = this.evaluateRules(config);
 
         return executor.start(config);
     }
@@ -85,9 +149,7 @@ class ExecutorRouter extends Executor {
      * @return {Promise}
      */
     _stop(config) {
-        const annotations = this.parseAnnotations(config.annotations || {});
-        const executorType = annotations[ANNOTATION_EXECUTOR_TYPE];
-        const executor = this[executorType] || this.defaultExecutor; // Route to executor (based on annotations) or use default executor
+        const executor = this.evaluateRules(config);
 
         return executor.stop(config);
     }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "A generic plugin for routing builds to specified executors",
   "main": "index.js",
   "scripts": {
-    "pretest": "eslint .",
-    "test": "jenkins-mocha --recursive",
+    "pretest": "eslint . --quiet",
+    "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --recursive --timeout 4000 --retries 1 --exit --color true",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {
@@ -33,10 +33,11 @@
   ],
   "devDependencies": {
     "chai": "^4.2.0",
-    "eslint": "^4.19.1",
-    "eslint-config-screwdriver": "^3.0.0",
-    "jenkins-mocha": "^6.0.0",
+    "eslint": "^6.8.0",
+    "eslint-config-screwdriver": "^5.0.3",
+    "mocha": "^7.0.1",
     "mockery": "^2.0.0",
+    "nyc": "^15.0.0",
     "sinon": "^4.5.0"
   },
   "dependencies": {

--- a/test/data/testExecutor.js
+++ b/test/data/testExecutor.js
@@ -2,7 +2,7 @@
 
 const ExecutorBase = require('screwdriver-executor-base');
 
-module.exports = (stubsMap) => {
+module.exports = stubsMap => {
     /**
      * Generic executor class for testing
      * @type {Class}
@@ -13,7 +13,7 @@ module.exports = (stubsMap) => {
 
             this.options = options;
 
-            Object.keys(stubsMap).forEach((key) => {
+            Object.keys(stubsMap).forEach(key => {
                 this[key] = stubsMap[key];
             });
         }


### PR DESCRIPTION
## Context

Screwdriver cluster has ability to support multiple build executors - k8s, k8s-vm, jenkins etc . Currently users can use annotation screwdriver.cd/executor to pin to a specific executor available in the build cluster, if they don't want to use the default executor selected by the cluster admin. But there is a need to support distributing builds to multiple executors with in a build cluster instead of always picking the default one.

## Objective

This PR implements a feature to select an executor based on the assigned weight configured in the cluster and keeps the default logic intact following this priority pattern.
executor annotations > executors with weight > default executor

## References

https://github.com/screwdriver-cd/screwdriver/issues/2083

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
