### PR TITLE
fix: Add parseInt to weightage

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ class ExecutorRouter extends Executor {
      * @return {String} executor name
      */
     getWeightedExecutor(executors) {
-        const totalWeight = executors.reduce((prev, curr) => prev + (curr.weightage || 0), 0);
+        const totalWeight = executors.reduce((prev, curr) => prev + (+curr.weightage || 0), 0);
 
         if (totalWeight === 0) {
             return undefined;
@@ -85,7 +85,7 @@ class ExecutorRouter extends Executor {
         let sum = 0;
 
         for (let i = 0; i < executors.length; i += 1) {
-            sum += executors[i].weightage;
+            sum += parseInt(executors[i].weightage, 10) || 0;
 
             if (number < sum) return executors[i].name;
         }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -622,5 +622,41 @@ describe('index test', () => {
                     assert.deepEqual(err, testError);
                 });
         });
+
+        it('selects correct executor when weightage is type string', () => {
+            executor = new Executor({
+                ecosystem,
+                defaultPlugin: 'example',
+                executor: [
+                    {
+                        name: 'k8s',
+                        weightage: '0',
+                        options: k8sPluginOptions
+                    },
+                    {
+                        name: 'example',
+                        weightage: '0',
+                        options: examplePluginOptions
+                    },
+                    {
+                        name: 'k8s-vm',
+                        weightage: '5',
+                        options: k8sVmPluginOptions
+                    }
+                ]
+            });
+            k8sVmExecutorMock._stop.resolves('k8sVmExecutorResult');
+
+            return executor
+                ._stop({
+                    buildId: 920
+                })
+                .then(result => {
+                    assert.strictEqual(result, 'k8sVmExecutorResult');
+                    assert.calledOnce(k8sVmExecutorMock._stop);
+                    assert.notCalled(exampleExecutorMock._stop);
+                    assert.notCalled(k8sExecutorMock._stop);
+                });
+        });
     });
 });


### PR DESCRIPTION
Context
K8s env variables are string so add parseInt to properties

Objective
This PR adds parseInt to weightage property of executors

License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.