### PR TITLE
feat: Add container exclusion to executor

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,11 @@ class ExecutorRouter extends Executor {
             },
             {
                 name: 'weighted',
-                check: () => this.getWeightedExecutor(this._executors)
+                check: buildConfig => {
+                    const allowedExecutors = this.checkExclusions(this._executors, buildConfig.container);
+
+                    return this.getWeightedExecutor(allowedExecutors);
+                }
             },
             {
                 name: 'default',
@@ -91,6 +95,26 @@ class ExecutorRouter extends Executor {
         }
 
         return executors[0].name;
+    }
+
+    /**
+     * Checks if executor is excluded for a container.
+     * @method checkExclusions
+     * @param {Array} executors
+     * @param {String} container
+     */
+    checkExclusions(executors, container) {
+        return executors.filter(executor => {
+            const { exclusions } = executor;
+
+            if (!exclusions) return true;
+
+            return !exclusions.some(item => {
+                const regEx = new RegExp(item, 'gi');
+
+                return container.match(regEx);
+            });
+        });
     }
 
     /**


### PR DESCRIPTION
## Context

Weighted logic for kata will not support some containers like rhel6 so we have to filter those out before selecting executor

## Objective

This PR adds a logic to check for exclusions of containers for specific executors.

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
