### PR TITLE
fix: fix for broken stop builds

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const ANNOTATION_EXECUTOR_TYPE = 'executor'; // Key in annotations object that maps to an executor NPM module
 const Executor = require('screwdriver-executor-base');
+const logger = require('screwdriver-logger');
 
 class ExecutorRouter extends Executor {
     /**
@@ -33,7 +34,7 @@ class ExecutorRouter extends Executor {
                 ExecutorPlugin = require(`screwdriver-executor-${plugin.name}`);
                 this._executors.push(plugin);
             } catch (err) {
-                console.error(err.message);
+                logger.error(err.message);
 
                 return;
             }
@@ -133,9 +134,13 @@ class ExecutorRouter extends Executor {
         let executorName;
 
         for (const rule of this._executorRules) {
-            executorName = rule.check(config);
-            if (executorName && this[executorName]) {
-                break;
+            try {
+                executorName = rule.check(config);
+                if (executorName && this[executorName]) {
+                    break;
+                }
+            } catch (err) {
+                logger.error(`Failed to validate executor rule ${rule.name}`, err);
             }
         }
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "sinon": "^4.5.0"
   },
   "dependencies": {
-    "screwdriver-executor-base": "^7.0.0"
+    "screwdriver-executor-base": "^7.0.0",
+    "screwdriver-logger": "^1.0.0"
   },
   "release": {
     "debug": false,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -549,6 +549,41 @@ describe('index test', () => {
                 });
         });
 
+        it('calls _stop with default executor on executor selection errrors', () => {
+            executor = new Executor({
+                ecosystem,
+                defaultPlugin: 'example',
+                executor: [
+                    {
+                        name: 'k8s',
+                        weightage: 20,
+                        options: k8sPluginOptions,
+                        exclusions: ['rhel6']
+                    },
+                    {
+                        name: 'example',
+                        weightage: 0,
+                        options: examplePluginOptions
+                    },
+                    {
+                        name: 'k8s-vm',
+                        weightage: 10,
+                        options: k8sVmPluginOptions
+                    }
+                ]
+            });
+
+            return executor
+                .stop({
+                    buildId: 920
+                })
+                .then(() => {
+                    assert.called(exampleExecutorMock._stop);
+                    assert.notCalled(k8sVmExecutorMock._stop);
+                    assert.notCalled(k8sExecutorMock._stop);
+                });
+        });
+
         it('calls _start with executor from annotation', () => {
             k8sVmExecutorMock._start.resolves('k8sVmExecutorResult');
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -549,7 +549,7 @@ describe('index test', () => {
                 });
         });
 
-        it('calls _stop with default executor on executor selection errrors', () => {
+        it('calls _stop with default executor on executor selection errors', () => {
             executor = new Executor({
                 ecosystem,
                 defaultPlugin: 'example',


### PR DESCRIPTION
## Context

When stop request is issued there is no container information. This cases failures with weighted executor logic. 

## Objective

Ignore executor selection errors so that default executor can be returned.

## References

https://github.com/screwdriver-cd/screwdriver/issues/2083

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
