### PR TITLE
feat(1958): Publish major version. BREAKING CHANGE: hapi v19

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-executor-router",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "A generic plugin for routing builds to specified executors",
   "main": "index.js",
   "scripts": {
@@ -41,6 +41,7 @@
     "sinon": "^4.5.0"
   },
   "dependencies": {
+    "screwdriver-data-schema": "git://github.com/screwdriver-cd/data-schema.git#hapi-v19",
     "screwdriver-executor-base": "^7.0.0",
     "screwdriver-logger": "^1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "sinon": "^4.5.0"
   },
   "dependencies": {
-    "screwdriver-data-schema": "git://github.com/screwdriver-cd/data-schema.git#hapi-v19",
-    "screwdriver-executor-base": "^7.0.0",
+    "screwdriver-data-schema": "^20.0.0",
+    "screwdriver-executor-base": "^8.0.0",
     "screwdriver-logger": "^1.0.0"
   },
   "release": {

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-    image: node:8
+    image: node:12
 
 jobs:
     main:


### PR DESCRIPTION
## Context

Upgrade to latest hapi js version v19 supported and stable version

## Objective

This PR publishes a new version of the package

## References

https://github.com/screwdriver-cd/screwdriver/issues/1958

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
