### PR TITLE
feat(2197): support multiple versions of same executor with different config

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,8 +30,10 @@ class ExecutorRouter extends Executor {
 
         executor.forEach(plugin => {
             try {
+                const pluginName = plugin.pluginName || plugin.name;
+
                 // eslint-disable-next-line global-require, import/no-dynamic-require
-                ExecutorPlugin = require(`screwdriver-executor-${plugin.name}`);
+                ExecutorPlugin = require(`screwdriver-executor-${pluginName}`);
                 this._executors.push(plugin);
             } catch (err) {
                 logger.error(err.message);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -92,6 +92,11 @@ describe('index test', () => {
                     options: k8sPluginOptions
                 },
                 {
+                    name: 'k8s-vm-sandbox',
+                    pluginName: 'k8s-vm',
+                    options: k8sVmPluginOptions
+                },
+                {
                     name: 'example',
                     options: examplePluginOptions
                 },
@@ -356,6 +361,27 @@ describe('index test', () => {
                     assert.strictEqual(result, 'exampleExecutorResult');
                     assert.calledOnce(exampleExecutorMock._start);
                     assert.notCalled(k8sExecutorMock._start);
+                });
+        });
+
+        it('uses proper executor when called with a different name', () => {
+            k8sExecutorMock._start.rejects();
+            k8sVmExecutorMock._start.resolves('k8sVmExecutorResult');
+
+            return executor
+                .start({
+                    annotations: {
+                        'screwdriver.cd/executor': 'k8s-vm-sandbox'
+                    },
+                    buildId: 920,
+                    container: 'node:12',
+                    apiUri: 'http://api.com',
+                    token: 'qwer'
+                })
+                .then(result => {
+                    assert.notCalled(k8sExecutorMock._start);
+                    assert.strictEqual(result, 'k8sVmExecutorResult');
+                    assert.calledOnce(k8sVmExecutorMock._start);
                 });
         });
 


### PR DESCRIPTION


## Objective

support multiple versions of same executor with different config

## References

https://github.com/screwdriver-cd/screwdriver/issues/2197

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
