### PR TITLE
feat(3171): Move pipeline template workflowGraph out of config into a new field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-executor-router",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "A generic plugin for routing builds to specified executors",
   "main": "index.js",
   "scripts": {
@@ -42,8 +42,8 @@
     "sinon": "^15.0.0"
   },
   "dependencies": {
-    "screwdriver-data-schema": "^23.0.4",
-    "screwdriver-executor-base": "^9.0.0",
+    "screwdriver-data-schema": "^24.0.0",
+    "screwdriver-executor-base": "^10.0.0",
     "screwdriver-logger": "^2.0.0"
   },
   "release": {


### PR DESCRIPTION
BREAKING CHANGE: Move workflowGraph out of config and keep it at the same level as config


## Context

Move pipeline template workflowGraph out of config into a new field

## Objective
Upgrading dependencies

## References

https://github.com/screwdriver-cd/screwdriver/issues/3171

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
